### PR TITLE
remove reverend in favor of path-to-regexp.compile

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var pathetic = require('pathetic');
-var reverend = require('reverend');
+var path2regexp = require('path-to-regexp');
 
 var pathematics = module.exports = function (map, url) {
   var parse = function (url) {
@@ -8,7 +8,7 @@ var pathematics = module.exports = function (map, url) {
   }
   
   function replaceSegments (segment) {
-    var url = reverend(segment.value, segment.params);
+    var url = path2regexp.compile(segment.value)(segment.params);
     
     return (url === '') ? undefined : url;
   }
@@ -18,7 +18,7 @@ var pathematics = module.exports = function (map, url) {
     var parsedUrl = replaceSegments(segment);
     
     return (!parsedUrl) ? {} : {
-      url: reverend(segment.value, segment.params),
+      url: path2regexp.compile(segment.value)(segment.params),
       meta: segment._originalValue
     }
   };

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "https://github.com/scottcorgan/pathematics",
   "dependencies": {
-    "pathetic": "~0.3.1",
-    "reverend": "~0.2.0"
+    "path-to-regexp": "^1.1.1",
+    "pathetic": "~0.3.1"
   },
   "devDependencies": {
     "mocha": "~1.18.2",


### PR DESCRIPTION
[Path-to-regexp](https://github.com/pillarjs/path-to-regexp), which powers [Reverend](https://github.com/krakenjs/reverend), has recently added the [ability to reverse routes](https://github.com/pillarjs/path-to-regexp#compile-reverse-path-to-regexp), rendering `Reverend` unnecessary. As such, `Reverend` is in the process of being deprecated.

The sole differences between the implementation in `Reverend` and that of `path-to-regexp` is a bit of duck-typing to prevent throws. This small amount of duck-typing can be seen in the [shim](http://github.com/krakenjs/reverend/blob/shim/index.js) branch.
